### PR TITLE
Update GitHub Actions pinning configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -112,6 +112,12 @@
         "patch",
         "renovate-deps"
       ]
+    },
+    {
+      "description": "Pin GitHub Actions to commit SHAs only for third-party repos (not Smartly-owned)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^smartlyio\\//"],
+      "pinDigests": false
     }
   ],
   "github-actions": {


### PR DESCRIPTION
Current renovate configuration will pin Smartly GHAs back.